### PR TITLE
IS-14021: Add working datatypes and improving pagination

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,15 @@
   "datatypes": {
     "customer": {
       "template": "templates/customer.json"
+    },
+    "product": {
+      "template": "templates/customer.json"
+    },
+    "productgroup": {
+      "template": "templates/productgroup.json"
+    },
+    "supplier": {
+      "template": "templates/customer.json"
     }
   },
   "system-template": "templates/system.json"

--- a/templates/customer.json
+++ b/templates/customer.json
@@ -1,12 +1,12 @@
 {
-  "_id": "{{@ system @}}-customer-collect",
+  "_id": "{{@ system @}}-{{@ datatype @}}-collect",
   "namespaced_identifiers": false,
   "source": {
     "id_expression": "{{ id }}",
     "operation": "list",
     "payload_property": "data",
     "properties": {
-      "datatype": "customer",
+      "datatype": "{{@ datatype @}}",
       "ordering": "Name asc",
       "skip": "0",
       "top": "20"

--- a/templates/customer.json
+++ b/templates/customer.json
@@ -1,18 +1,17 @@
 {
-  "_id": "{{@ system @}}-{{@ datatype @}}-collect",
+  "_id": "{{@ system @}}-customer-collect",
   "namespaced_identifiers": false,
   "source": {
     "id_expression": "{{ id }}",
     "operation": "list",
     "payload_property": "data",
     "properties": {
-      "datatype": "{{@ datatype @}}",
+      "datatype": "customer",
       "ordering": "Name asc",
       "skip": "0",
       "top": "20"
     },
     "system": "{{@ system @}}",
-    "trace": true,
     "type": "rest"
   },
   "type": "pipe"

--- a/templates/system.json
+++ b/templates/system.json
@@ -18,10 +18,10 @@
       ],
       "params": {
         "$orderby": "{{ properties.ordering }}",
-        "$skip": "{% if (previous_request_headers['X-Sesam-Page'] is defined) %}{{ 10|int*headers['X-Sesam-Page']|int }}{% else %}0{% endif %}sesam:markjson",
+        "$skip": "{% if (previous_request_headers['X-Sesam-Page'] is defined) %}{{ properties.top|int*(headers['X-Sesam-Page']|int-1) }}{% else %}0{% endif %}sesam:markjson",
         "$top": "{{ properties.top }}"
       },
-      "url": "/{{ properties.datatype|capitalize }}"
+      "url": "{{ properties.datatype|capitalize }}"
     }
   },
   "type": "system:rest",


### PR DESCRIPTION
These datatypes worked.

I struggle adding some of the mapped datatypes. I'll keep trying but I wanted to add the datatypes that are working as is, since the remaining datatypes are not that easy to add.

I fear the ones that looked at the API misread a bit. Which I appreciate since the API docs for PowerOffice is quite bad. Albeit, the services and types section that show all "supported" datatypes differ. Within types you see all the mapped datatypes, but within services you only see a subsection, and some are having a semantically funky endpoint:
https://api.poweroffice.net/Web/docs/index.html#Reference/Rest/Services.md